### PR TITLE
Remove attribute on null.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+.idea
+
+# ENSIME specific
+.ensime_cache/
+.ensime

--- a/monadic-html/src/main/scala/mhtml/mount.scala
+++ b/monadic-html/src/main/scala/mhtml/mount.scala
@@ -77,7 +77,7 @@ object mount {
     case f: Function1[_, Unit @ unchecked] =>
       parent.setEventListener(m.key, f)
     case _ =>
-      parent.setMetadata(m, v.toString)
+      parent.setMetadata(m, v)
       Cancelable.empty
   }
 
@@ -88,10 +88,15 @@ object mount {
       Cancelable(() => dyn.updateDynamic(key)(null))
     }
 
-    def setMetadata(m: MetaData, v: String): Unit = {
+    def setMetadata(m: MetaData, v: Any): Unit = {
       val htmlNode = node.asInstanceOf[dom.html.Html]
       def set(k: String): Unit =
-        if (k == "style") htmlNode.style.cssText = v else htmlNode.setAttribute(k, v)
+        if (v == null) htmlNode.removeAttribute(k)
+        else {
+          val str = v.toString
+          if (k == "style") htmlNode.style.cssText = str
+          else htmlNode.setAttribute(k, str)
+        }
       m match {
         case m: PrefixedAttribute => set(s"${m.pre}:${m.key}")
         case _ => set(m.key)

--- a/tests/src/test/scala/mhtml/tests.scala
+++ b/tests/src/test/scala/mhtml/tests.scala
@@ -50,6 +50,8 @@ class Tests extends FunSuite {
     assert(div.innerHTML == """<hr id="oldId">""")
     id := "newId"
     assert(div.innerHTML == """<hr id="newId">""")
+    id := null
+    assert(div.innerHTML == """<hr>""")
   }
 
   test("Updating attribute does not replace nodes") {


### PR DESCRIPTION
To mimic scala-xml behavior, if an attribute value is null, then the
attribute should be removed. The previous behavior was a null pointer
exception.