### PR TITLE
Add Further Reading section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,14 @@ implicit class SequencingListFFS[A](self: List[Rx[A]]) {
 ```scala
 import cats.implicits._, mhtml.cats._
 ```
+
+## Further reading
+
+[*Unidirectional User Interface Architectures*](http://staltz.com/unidirectional-user-interface-architectures.html) by André Staltz
+
+This blog post presents several existing solution to handle mutable state in user interfaces. It explains the core ideas behind Flux, Redux, Elm & others, and presents a new approach, *nested dialogues*, which is similar to what you would write in `monadic-html`.
+
+[*Controlling Time and Space: understanding the many formulations of FRP*](https://www.youtube.com/watch?v=Agu6jipKfYw) by Evan Czaplicki
+
+This presentation gives an overview of various formulations of FRP. The talked is focused on how different systems deal with the `flatMap` operator. When combined with a `fold` operator, `flatMap` is problematic: it either leaks memory or break referential transparency. Elm solution is to simply avoid the `flatMap` operator altogether (programs can exclusively be written using the "applicative style"). `monadic-html` takes the opposite approach of not exposing a `fold`.
+


### PR DESCRIPTION
@olafurpg  The README looks pretty good now, do you think there is anything missing for a small announcement? Did you have something particular in mind or do you think something like "Announcing monadic-html, a tiny DOM binding library for Scala.js" with a link to the repo would do?

By the way I've also wrote an abstract for a student project, if you have time to review it :smile::

Title: DOM diffing algorithm in Scala.js

Abstract: Building web using interfaces using functional reactive programming requires a mechanism for bind binding to the DOM. One solution uses is to use the so-called *precise binding*: by mutating data in a fine grain way (for example, using case classes with mutable fields), it is possible to propagate changes very precisely to the DOM, only recreating nodes and attributes when necessary. This is the approach currently employed by the [monadic-html](https://github.com/OlivierBlanvillain/monadic-html) binding library. However, in most cases, users want to manipulate immutable data structure, thus reducing the precision of updates which results in decrease in performances. The goal of this project would be to design a DOM diffing algorithm for Scala.js, and to integrate it with the existing *precise binding* approach to end up with an hybrid solution. Depending on time, the project could include benchmarks to compare this hybrid binding solution (all written in Scala.js) against state of the art frameworks such as Facebook React. Both semester project and Master project possible.