### PR TITLE
Bump cats version to 8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
 val scalajsdom = "0.9.1"
 val scalaxml   = "1.0.6"
 val scalatest  = "3.0.0"
-val cats       = "0.7.2"
+val cats       = "0.8.1"
 
 scalaVersion  in ThisBuild := "2.11.8"
+
+crossScalaVersions := Seq("2.12.0")
 
 lazy val root = project.in(file("."))
   .aggregate(
@@ -23,7 +25,7 @@ lazy val `monadic-html` = project
   .settings(publishSettings: _*)
   .settings(libraryDependencies ++= Seq(
     "org.scala-js" %%% "scalajs-dom" % scalajsdom,
-    "in.nvilla"    %%% "scala-xml"   % scalaxml)) // Awaiting https://github.com/scala/scala-xml/pull/109
+    "in.nvilla" % "scala-xml_sjs0.6_2.11"   % scalaxml)) // Awaiting https://github.com/scala/scala-xml/pull/109
 
 lazy val `monadic-rxJS`  = `monadic-rx`.js
 lazy val `monadic-rxJVM` = `monadic-rx`.jvm
@@ -67,7 +69,6 @@ scalacOptions in ThisBuild := Seq(
   "-Xfatal-warnings",
   "-Xfuture",
   "-Xlint",
-  "-Yinline-warnings",
   "-Yno-adapted-args",
   "-Ywarn-numeric-widen",
   "-Ywarn-unused-import",

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,6 @@ val cats       = "0.8.1"
 
 scalaVersion  in ThisBuild := "2.11.8"
 
-crossScalaVersions := Seq("2.12.0")
-
 lazy val root = project.in(file("."))
   .aggregate(
     `monadic-html`,
@@ -25,7 +23,7 @@ lazy val `monadic-html` = project
   .settings(publishSettings: _*)
   .settings(libraryDependencies ++= Seq(
     "org.scala-js" %%% "scalajs-dom" % scalajsdom,
-    "in.nvilla" % "scala-xml_sjs0.6_2.11"   % scalaxml)) // Awaiting https://github.com/scala/scala-xml/pull/109
+    "in.nvilla"    %%% "scala-xml"   % scalaxml)) // Awaiting https://github.com/scala/scala-xml/pull/109
 
 lazy val `monadic-rxJS`  = `monadic-rx`.js
 lazy val `monadic-rxJVM` = `monadic-rx`.jvm
@@ -69,6 +67,7 @@ scalacOptions in ThisBuild := Seq(
   "-Xfatal-warnings",
   "-Xfuture",
   "-Xlint",
+  "-Yinline-warnings",
   "-Yno-adapted-args",
   "-Ywarn-numeric-widen",
   "-Ywarn-unused-import",

--- a/monadic-rx-cats/src/main/scala/mhtml/cats.scala
+++ b/monadic-rx-cats/src/main/scala/mhtml/cats.scala
@@ -12,7 +12,10 @@ object cats {
         fa.flatMap(f)
 
       def tailRecM[A, B](a: A)(f: A => Rx[Either[A, B]]): Rx[B] =
-        defaultTailRecM(a)(f)
+        flatMap(f(a)) {
+          case Right(b) => pure(b)
+          case Left(nextA) => tailRecM(nextA)(f)
+        }
 
       def empty[A]: Rx[A] =
         new Var[A](Non, _ => Cancelable.empty)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.11


### PR DESCRIPTION
I bumped version of cats to 8.1 as well and fixed build errors. I use your custom scala-xml artifacts for both 2.11.8 and 2.12.0, so you will probably want to cross-build it as well.