### PR TITLE
add namespace to node and use createElementNS if present

### DIFF
--- a/monadic-html/src/main/scala/mhtml/mount.scala
+++ b/monadic-html/src/main/scala/mhtml/mount.scala
@@ -14,9 +14,9 @@ object mount {
 
   private def mountNode(parent: DomNode, child: XmlNode, startPoint: Option[DomNode], config: MountSettings): Cancelable =
     child match {
-      case e @ Elem(label, metadata, child @ _*) =>
+      case e @ Elem(label, metadata, ns, child @ _*) =>
         config.inspectElement(label)
-        val elemNode = dom.document.createElement(label)
+        val elemNode = ns.map(dom.document.createElementNS(_, label)).getOrElse(dom.document.createElement(label))
         val cancelMetadata = metadata.map { m => mountMetadata(elemNode, m, m.value.asInstanceOf[Atom[_]].data, config) }
         val cancelChild = child.map(c => mountNode(elemNode, c, None, config))
         parent.mountHere(elemNode, startPoint)

--- a/monadic-html/src/main/scala/mhtml/mount.scala
+++ b/monadic-html/src/main/scala/mhtml/mount.scala
@@ -14,10 +14,10 @@ object mount {
 
   private def mountNode(parent: DomNode, child: XmlNode, startPoint: Option[DomNode], config: MountSettings): Cancelable =
     child match {
-      case e @ Elem(label, metadata, ns, child @ _*) =>
+      case e @ Elem(_, label, metadata, scope, child @ _*) =>
         config.inspectElement(label)
-        val elemNode = ns.map(dom.document.createElementNS(_, label)).getOrElse(dom.document.createElement(label))
-        val cancelMetadata = metadata.map { m => mountMetadata(elemNode, m, m.value.asInstanceOf[Atom[_]].data, config) }
+        val elemNode = e.namespace.map(dom.document.createElementNS(_, label)).getOrElse(dom.document.createElement(label))
+        val cancelMetadata = metadata.map { m => mountMetadata(elemNode, scope, m, m.value.asInstanceOf[Atom[_]].data, config) }
         val cancelChild = child.map(c => mountNode(elemNode, c, None, config))
         parent.mountHere(elemNode, startPoint)
         Cancelable { () => cancelMetadata.foreach(_.cancel()); cancelChild.foreach(_.cancel()) }
@@ -73,15 +73,15 @@ object mount {
       }
     }
 
-  private def mountMetadata(parent: DomNode, m: MetaData, v: Any, config: MountSettings): Cancelable = v match {
+  private def mountMetadata(parent: DomNode, scope: Option[Scope], m: MetaData, v: Any, config: MountSettings): Cancelable = v match {
     case Some(x: Any) =>
-      mountMetadata(parent, m, x, config)
+      mountMetadata(parent, scope, m, x, config)
     case r: Rx[_] =>
       val rx: Rx[_] = r
       var cancelable = Cancelable.empty
       rx.foreach { value =>
         cancelable.cancel
-        cancelable = mountMetadata(parent, m, value, config)
+        cancelable = mountMetadata(parent, scope, m, value, config)
       } alsoCanceling (() => cancelable)
     case f: Function0[Unit @ unchecked] =>
       config.inspectEvent(m.key)
@@ -90,7 +90,7 @@ object mount {
       config.inspectEvent(m.key)
       parent.setEventListener(m.key, f)
     case _ =>
-      parent.setMetadata(m, v, config)
+      parent.setMetadata(scope, m, v, config)
       Cancelable.empty
   }
 
@@ -101,9 +101,9 @@ object mount {
       Cancelable(() => dyn.updateDynamic(key)(null))
     }
 
-    def setMetadata(m: MetaData, v: Any, config: MountSettings): Unit = {
+    def setMetadata(scope: Option[Scope], m: MetaData, v: Any, config: MountSettings): Unit = {
       val htmlNode = node.asInstanceOf[dom.html.Html]
-      def set(key: String): Unit = v match {
+      def set(key: String, prefix: Option[String]): Unit = v match {
         case null | None | false => htmlNode.removeAttribute(key)
         case _ =>
           config.inspectAttributeKey(key)
@@ -112,11 +112,15 @@ object mount {
             case _    => v.toString
           }
           if (key == "style") htmlNode.style.cssText = value
-          else htmlNode.setAttribute(key, value)
+          else prefix.flatMap(prefix => scope.flatMap(_.namespaceURI(prefix))).fold {
+            htmlNode.setAttribute(key, value)
+          } { ns =>
+            htmlNode setAttributeNS(ns, key, value)
+          }
       }
       m match {
-        case m: PrefixedAttribute[_] => set(s"${m.pre}:${m.key}")
-        case _ => set(m.key)
+        case m: PrefixedAttribute[_] => set(s"${m.pre}:${m.key}", Some(m.pre))
+        case _ => set(m.key, None)
       }
     }
 

--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -12,8 +12,7 @@ import language.higherKinds
 sealed trait Node {
   def scope: Option[Scope] = None
   def prefix: Option[String] = None
-  def namespace: Option[String] = if (prefix.isDefined) prefix.flatMap(namespaceURI) else scope.flatMap(_.namespaceURI(null))
-  def namespaceURI(prefix: String): Option[String] = scope.flatMap(_.namespaceURI(prefix))
+  def namespace: Option[String] = scope.flatMap(_.namespaceURI(prefix.orNull))
 }
 
 /** A hack to group XML nodes in one node. */
@@ -99,8 +98,6 @@ sealed trait MetaData extends Iterable[MetaData] {
 
   def iterator: Iterator[MetaData] =
     Iterator.single(this) ++ next.iterator
-
-  def namespace: Option[String] = value.namespace
 }
 
 case object Null extends MetaData {
@@ -117,8 +114,6 @@ final case class PrefixedAttribute[T](
   next: MetaData
 )(implicit ev: XmlAttributeEmbeddable[T]) extends MetaData {
   override val value: Node = ev.toNode(e)
-
-  override def namespace: Option[String] = value.namespaceURI(pre)
 }
 
 final case class UnprefixedAttribute[T](

--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -18,6 +18,7 @@ final case class Group(nodes: Seq[Node]) extends Node
 final case class Elem(
   label: String,
   attributes1: MetaData,
+  namespace: Option[String],
   child: Node*
 ) extends Node {
   // m, former minimizeEmpty, and p former prefix are now thrown away.
@@ -32,6 +33,11 @@ final case class Elem(
         case _ => acc
       }
       merge(a, s)
+    }, s match {
+      case TopScope => None
+      case NamespaceBinding(null, url, next) => Some(url)
+      case NamespaceBinding(key, url, next) => Some(url)
+      case _ => None
     }, c: _*)
 }
 

--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -9,21 +9,27 @@ import language.higherKinds
 // directly in scalac paser). `NoteSeq` disappeared, `Node <:!< Seq[Node]`...
 
 /** Trait representing XML tree. */
-sealed trait Node
+sealed trait Node {
+  def scope: Option[Scope] = None
+  def prefix: Option[String] = None
+  def namespace: Option[String] = if (prefix.isDefined) prefix.flatMap(namespaceURI) else scope.flatMap(_.namespaceURI(null))
+  def namespaceURI(prefix: String): Option[String] = scope.flatMap(_.namespaceURI(prefix))
+}
 
 /** A hack to group XML nodes in one node. */
 final case class Group(nodes: Seq[Node]) extends Node
 
 /** XML element. */
 final case class Elem(
+  override val prefix: Option[String],
   label: String,
   attributes1: MetaData,
-  namespace: Option[String],
+  override val scope: Option[Scope],
   child: Node*
 ) extends Node {
-  // m, former minimizeEmpty, and p former prefix are now thrown away.
+  // m, former minimizeEmpty, is now thrown away.
   def this(p: String, l: String, a: MetaData, s: Scope, m: Boolean, c: Node*) =
-    this(l, {
+    this(Option(p), l, {
       // Merges attributes stored in as scope with other metadata
       def merge(acc: MetaData, s: Scope): MetaData = s match {
         case NamespaceBinding(null, url, next) =>
@@ -33,12 +39,7 @@ final case class Elem(
         case _ => acc
       }
       merge(a, s)
-    }, s match {
-      case TopScope => None
-      case NamespaceBinding(null, url, next) => Some(url)
-      case NamespaceBinding(key, url, next) => Some(url)
-      case _ => None
-    }, c: _*)
+    }, Some(s), c: _*)
 }
 
 /** XML leaf for comments. */
@@ -55,22 +56,29 @@ class Atom[+A](val data: A) extends Node
 
 // Scopes ---------------------------------------------------------------------
 
-sealed trait Scope
+sealed trait Scope {
+  def namespaceURI(prefix: String) : Option[String]
+}
 
 // Used by scalac for xmlns prefixed attributes
-class NamespaceBinding(key: String, url: String, next: Scope) extends Scope {
+class NamespaceBinding(key: String, url: String, next: NamespaceBinding) extends Scope {
   def isEmpty = false
   def get     = this
   def _1      = key
   def _2      = url
   def _3      = next
+
+  def namespaceURI(prefix: String) : Option[String] =
+    if (prefix == key) Some(url) else next namespaceURI prefix
 }
 
 object NamespaceBinding {
   def unapply(s: NamespaceBinding): NamespaceBinding = s
 }
 
-final case object TopScope extends NamespaceBinding(null, null, null)
+final case object TopScope extends NamespaceBinding(null, null, null) {
+  override def namespaceURI(prefix: String): Option[String] = None
+}
 
 // XML Metadata ---------------------------------------------------------------
 
@@ -82,7 +90,7 @@ final case object TopScope extends NamespaceBinding(null, null, null)
   *  attributes. Every instance of this class is either
   *  - an instance of `UnprefixedAttribute key,value` or
   *  - an instance of `PrefixedAttribute namespace_prefix,key,value` or
-  *  - `Null, the empty attribute list. */
+  *  - `Null`, the empty attribute list. */
 sealed trait MetaData extends Iterable[MetaData] {
   def hasNext = (Null != next)
   def key: String
@@ -91,6 +99,8 @@ sealed trait MetaData extends Iterable[MetaData] {
 
   def iterator: Iterator[MetaData] =
     Iterator.single(this) ++ next.iterator
+
+  def namespace: Option[String] = value.namespace
 }
 
 case object Null extends MetaData {
@@ -107,6 +117,8 @@ final case class PrefixedAttribute[T](
   next: MetaData
 )(implicit ev: XmlAttributeEmbeddable[T]) extends MetaData {
   override val value: Node = ev.toNode(e)
+
+  override def namespace: Option[String] = value.namespaceURI(pre)
 }
 
 final case class UnprefixedAttribute[T](

--- a/tests/src/test/scala/mhtml/RenderTests.scala
+++ b/tests/src/test/scala/mhtml/RenderTests.scala
@@ -1,6 +1,7 @@
 package mhtml
 
 import org.scalajs.dom
+import org.scalajs.dom.raw.SVGAElement
 import org.scalatest.FunSuite
 
 class RenderTests extends FunSuite {
@@ -60,11 +61,27 @@ class RenderTests extends FunSuite {
     assert(svgNode.namespaceURI == "http://hello.com")
   }
 
+  test("attributes with prefix are set with namespace") {
+    val svg =
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <a xlink:href="test.html">
+          <rect x="10" y="10" ry="5" width="40" height="40" />
+        </a>
+      </svg>
+
+    val linkNode = firstByTagName(mountNode(svg), "a").asInstanceOf[SVGAElement]
+
+    assert(linkNode.namespaceURI == "http://www.w3.org/2000/svg")
+    assert(linkNode.getAttributeNS("http://www.w3.org/1999/xlink", "href") == "test.html")
+    assert(linkNode.getAttribute("href") == null)
+    assert(linkNode.getAttribute("xlink:href") == "test.html")
+  }
+
   test("created element has default namespace if no namespace defined") {
     val divNode = firstByTagName(mountNode(<div></div>), "div")
     assert(divNode.namespaceURI == "http://www.w3.org/1999/xhtml")
   }
 
-  def firstByTagName(parent: dom.raw.Element, tagName: String): dom.raw.Node =
-    parent.getElementsByTagName(tagName)(0)
+  def firstByTagName(parent: dom.raw.Element, tagName: String): dom.Element =
+    parent.getElementsByTagName(tagName)(0).asInstanceOf[dom.Element]
 }

--- a/tests/src/test/scala/mhtml/RenderTests.scala
+++ b/tests/src/test/scala/mhtml/RenderTests.scala
@@ -4,10 +4,12 @@ import org.scalajs.dom
 import org.scalatest.FunSuite
 
 class RenderTests extends FunSuite {
-  def render(node: xml.Node): String = {
+  def render(node: xml.Node): String = mountNode(node).innerHTML
+
+  def mountNode(node: xml.Node): dom.raw.Element = {
     val div = dom.document.createElement("div")
     mount(div, node)
-    div.innerHTML
+    div
   }
 
   def check(node: xml.Node, expected: String): Unit =
@@ -52,4 +54,9 @@ class RenderTests extends FunSuite {
   // Position of xmlns among other attributes is also lost forever in the parser
   check(<svg id="I" xmlns="http://hello.com" class="C"></svg>,
      """<svg xmlns="http://hello.com" id="I" class="C"></svg>""")
+
+  test("created element has namespace if defined") {
+    val svgNode = mountNode(<svg xmlns="http://hello.com"></svg>).getElementsByTagName("svg")(0)
+    assert(svgNode.namespaceURI == "http://hello.com")
+  }
 }

--- a/tests/src/test/scala/mhtml/RenderTests.scala
+++ b/tests/src/test/scala/mhtml/RenderTests.scala
@@ -56,7 +56,15 @@ class RenderTests extends FunSuite {
      """<svg xmlns="http://hello.com" id="I" class="C"></svg>""")
 
   test("created element has namespace if defined") {
-    val svgNode = mountNode(<svg xmlns="http://hello.com"></svg>).getElementsByTagName("svg")(0)
+    val svgNode = firstByTagName(mountNode(<svg xmlns="http://hello.com"></svg>), "svg")
     assert(svgNode.namespaceURI == "http://hello.com")
   }
+
+  test("created element has default namespace if no namespace defined") {
+    val divNode = firstByTagName(mountNode(<div></div>), "div")
+    assert(divNode.namespaceURI == "http://www.w3.org/1999/xhtml")
+  }
+
+  def firstByTagName(parent: dom.raw.Element, tagName: String): dom.raw.Node =
+    parent.getElementsByTagName(tagName)(0)
 }


### PR DESCRIPTION
some nodes like svg will only work properly with createElementNS
so the namespace is needed during node creation. this is a small patch to fix that