### PR TITLE
Remove .impure.value and document product

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,26 @@ This section presents the `Rx` API in its entirety. Let's start with the referen
 
     Dynamically switch between different `Rx`s according to the given
     function, applied on each element of this `Rx`. Each switch will cancel
-    the subscriptions for the previous outgoing `Rx`, and lunch a subscriptions
-    on the next `Rx`.
+    the subscriptions for the previous outgoing `Rx` and start a new
+    subscription on the next `Rx`.
 
-    Together with `Rx#map` and `Rx.apply`, flatMap, `Rx` is a `Monad`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
+    Together with `Rx#map` and `Rx.apply`, flatMap forms a `Monad`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
+
+-  `def product[B](other: Rx[B]): Rx[(A, B)]`
+
+    Create the Cartesian product of two `Rx`. The output tuple contains the
+    latest values from each input `Rx`, which updates whenever the value from
+    either input `Rx` update. This method is faster than combining `Rx`s using
+    `for { a <- ra; b <- rb } yield (a, b)`.
+
+    ```
+    // r1      => 0     8                       9     ...
+    // r2      => 1           4     5     6           ...
+    // product => (0,1) (8,1) (8,4) (8,5) (8,6) (9,6) ...
+    ```
+
+    This method, together with `Rx.apply`, forms am `Applicative`.
+    `|@|` syntax is available via the `monadic-rx-cats` package.
 
 -  `def dropRepeats: Rx[A]`
 
@@ -190,7 +206,8 @@ This section presents the `Rx` API in its entirety. Let's start with the referen
     // merged => 0 8 4 3 3 ...
     ```
 
-    With this operation, `Rx` is a `Semigroup`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
+    With this operation, `Rx` forms a `Semigroup`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
+    `|+|` syntax is available via the `monadic-rx-cats` package.
 
 -  `def foldp[B](seed: B)(step: (B, A) => B): Rx[B]`
 

--- a/monadic-rx/shared/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/shared/src/main/scala/mhtml/rx.scala
@@ -19,19 +19,27 @@ sealed trait Rx[+A] { self =>
   /**
    * Dynamically switch between different `Rx`s according to the given
    * function, applied on each element of this `Rx`. Each switch will cancel
-   * the subscriptions for the previous outgoing `Rx`, and lunch a subscriptions
-   * on the next `Rx`.
+   * the subscriptions for the previous outgoing `Rx` and start a new
+   * subscription on the next `Rx`.
    *
    * Together with `Rx#map` and `Rx.apply`, flatMap forms a `Monad`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
    */
   def flatMap[B](f: A => Rx[B]): Rx[B] = FlatMap[A, B](this, f)
 
   /**
-   * Product of two `Rx`. A fast alternative to
+   * Create the Cartesian product of two `Rx`. The output tuple contains the
+   * latest values from each input `Rx`, which updates whenever the value from
+   * either input `Rx` update. This method is faster than combining `Rx`s using
+   * `for { a <- ra; b <- rb } yield (a, b)`.
    *
    * ```
-   * for { a <- ra; b <- rb } yield (a, b)
+   * // r1      => 0     8                       9     ...
+   * // r2      => 1           4     5     6           ...
+   * // product => (0,1) (8,1) (8,4) (8,5) (8,6) (9,6) ...
    * ```
+   *
+   * This method, together with `Rx.apply`, forms am `Applicative`.
+   * `|@|` syntax is available via the `monadic-rx-cats` package.
    */
   def product[B](other: Rx[B]): Rx[(A, B)] = Product[A, B](this, other)
 
@@ -63,7 +71,8 @@ sealed trait Rx[+A] { self =>
    * // merged => 0 8 4 3 3 ...
    * ```
    *
-   * With this operation, `Rx` is a `Semigroup`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
+   * With this operation, `Rx` forms a `Semigroup`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
+   * `|+|` syntax is available via the `monadic-rx-cats` package.
    */
   def merge[B >: A](other: Rx[B]): Rx[B] = Merge[A, B](this, other)
 

--- a/tests/src/test/scala/mhtml/RxTests.scala
+++ b/tests/src/test/scala/mhtml/RxTests.scala
@@ -3,6 +3,19 @@ package mhtml
 import org.scalatest.FunSuite
 
 class RxTests extends FunSuite {
+  implicit class MoreImpureStuff[A](impure: RxImpureOps[A]) {
+    def value: A = {
+      var v: Option[A] = None
+      impure.foreach(a => v = Some(a)).cancel
+      // This can never happen if using the default Rx/Var constructors and
+      // methods. The proof is a simple case analysis showing that every method
+      // preserves non emptiness. Var created with unsafeCreate Messing up with
+      // Var unsafe constructor or internal could lead to this exception.
+      def error = new NoSuchElementException("Requesting value of an empty Rx.")
+      v.getOrElse(throw error)
+    }
+  }
+
   test("Scala.Rx README leak") {
     var count: Int = 0
     val a: Var[Int] = Var(1)

--- a/tests/src/test/scala/mhtml/RxTests.scala
+++ b/tests/src/test/scala/mhtml/RxTests.scala
@@ -294,4 +294,28 @@ class RxTests extends FunSuite {
       assert(rx1.subscribers.isEmpty && rx2.subscribers.isEmpty)
     }
   }
+
+  test("product") {
+    val rx1: Var[Int] = Var(0)
+    val rx2: Var[Int] = Var(1)
+    val product: Rx[(Int, Int)] = rx1.product(rx2)
+    var rx1List: List[Int] = Nil
+    var rx2List: List[Int] = Nil
+    var productList: List[(Int, Int)] = Nil
+    val cc1 = rx1.impure.foreach(n => rx1List = rx1List :+ n)
+    val cc2 = rx2.impure.foreach(n => rx2List = rx2List :+ n)
+    val ccm = product.impure.foreach(n => productList = productList :+ n)
+    rx1 := 8
+    rx2 := 4
+    rx2 := 5
+    rx2 := 6
+    rx1 := 9
+    assert(rx1List == List(0, 8, 9))
+    assert(rx2List == List(1, 4, 5, 6))
+    assert(productList == List((0, 1), (8, 1), (8, 4), (8, 5), (8, 6), (9, 6)))
+    cc1.cancel
+    cc2.cancel
+    ccm.cancel
+    assert(rx1.subscribers.isEmpty && rx2.subscribers.isEmpty)
+  }
 }


### PR DESCRIPTION
`.impure.value` creates confusion: it makes it look like `Rx` have a current value when they actually don't.

This can be particularly surprising with expressions like `rx.fold(0)(_ + _).impure.value` that will always evaluate to `0` because `.value` creates and cancels its subscription on every call...

So my proposal it to remove this altogether.

I also created an `RxImpureOps` to replace the `val impure = object {}`. This should make it easier to add impure methods like `.impure.oreachNext` & co.