### PR TITLE
verifying EntityRef behavior and adjusting README accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ There are a couple of ways. The first is to inject it directly into a node. To g
 
 ```scala
 def space(nn: Int): Node = Group(Seq.fill(nn)(EntityRef("nbsp")))
-<span>{space(2)}</span> // results in  <span>"&npsp;""&npsp;"</span>
+<span>{space(2)}</span> // results in <span>&npsp;&npsp;</span>
 ```
 
 #### Global mutable state, Booo! Booo!!!

--- a/tests/src/test/scala/mhtml/RenderTests.scala
+++ b/tests/src/test/scala/mhtml/RenderTests.scala
@@ -4,6 +4,8 @@ import org.scalajs.dom
 import org.scalajs.dom.raw.SVGAElement
 import org.scalatest.FunSuite
 
+import scala.xml.EntityRef
+
 class RenderTests extends FunSuite {
   def render(node: xml.Node): String = mountNode(node).innerHTML
 
@@ -41,6 +43,13 @@ class RenderTests extends FunSuite {
   check(<form disabled={Some(Rx(true))}>4</form> , """<form disabled="">4</form>""")
 
   check(<p>{emptyHTML}</p>                       , "<p></p>")
+
+  check(
+    <div>{Seq(
+      EntityRef("amp"), EntityRef("lt"), EntityRef("copy"), EntityRef("lambda")
+    )}</div>,
+    "<div>&amp;&lt;©λ</div>"
+  )
 
   check(<svg xmlns="http://hello.com"></svg>,
      """<svg xmlns="http://hello.com"></svg>""")


### PR DESCRIPTION
Turns out, one shouldn't trust a DOM inspector for truth; as mentioned in #44, there aren't actually quotes showing up int he generated html.