### PR TITLE
Added copy method to Elem

### DIFF
--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -47,7 +47,7 @@ final case class Elem(
     label: String = this.label,
     attributes1: MetaData = this.attributes1,
     scope: Option[Scope] = this.scope,
-    child: Seq[Node] = this.child.toSeq): Elem = Elem(prefix, label, attributes1, scope, child: _*)
+    child: Seq[Node] = this.child): Elem = Elem(prefix, label, attributes1, scope, child: _*)
 }
 
 /** XML leaf for comments. */

--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -41,6 +41,13 @@ final case class Elem(
       }
       merge(a, s)
     }, Some(s), c: _*)
+
+  def copy(
+    prefix: Option[String] = this.prefix,
+    label: String = this.label,
+    attributes1: MetaData = this.attributes1,
+    scope: Option[Scope] = this.scope,
+    child: Seq[Node] = this.child.toSeq): Elem = Elem(prefix, label, attributes1, scope, child: _*)
 }
 
 /** XML leaf for comments. */


### PR DESCRIPTION
Even though `Elem` is a case class it doesn't have a copy method because it has a [repeated parameter](https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#case-classes).