### PR TITLE
Fix xml to string

### DIFF
--- a/examples/src/main/scala/mhtml/examples/Examples.scala
+++ b/examples/src/main/scala/mhtml/examples/Examples.scala
@@ -88,7 +88,9 @@ object Main extends JSApp {
       {activeExample.map(_.demo)}
     </div>
 
-  def main(): Unit =
+  def main(): Unit = {
     mount(dom.document.body, mainApp)
+    ()
+  }
 }
 

--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -101,21 +101,25 @@ final case object TopScope extends NamespaceBinding(null, null, null) {
  *  - an instance of `PrefixedAttribute namespace_prefix,key,value` or
  *  - `Null`, the empty attribute list.
  */
-sealed trait MetaData extends Iterable[MetaData] {
+sealed trait MetaData {
   def hasNext = (Null != next)
   def key: String
   def value: Node
   def next: MetaData
-
-  def iterator: Iterator[MetaData] =
-    Iterator.single(this) ++ next.iterator
+  def map[T](f: MetaData => T): List[T] = {
+    def map0(acc: List[T], m: MetaData): List[T] =
+      m match {
+        case Null => acc
+        case any  => map0(f(any) :: acc, m.next)
+      }
+    map0(Nil, this)
+  }
 }
 
 case object Null extends MetaData {
   def next = null
   def key = null
   def value = null
-  override def iterator = Iterator.empty
 }
 
 final case class PrefixedAttribute[T: XmlAttributeEmbeddable](

--- a/monadic-html/src/test/scala/mhtml/HtmlTests.scala
+++ b/monadic-html/src/test/scala/mhtml/HtmlTests.scala
@@ -474,4 +474,10 @@ class HtmlTests extends FunSuite {
     val root = dom.document.createElement("div")
     mount(root, view(store))
   }
+
+  test("toString on xml node") {
+    val node = <button class="c" id="1">Click Me!</button>
+    val makeMeDream = """Elem(None,button,UnprefixedAttribute(xmlns,null,UnprefixedAttribute(class,Text(c),UnprefixedAttribute(id,Text(1),Null))),Some(TopScope),ArrayBuffer(Text(Click Me!)))"""
+    assert(node.toString == makeMeDream)
+  }
 }


### PR DESCRIPTION
The cause of the problem was that `MetaData` where getting an unsound default `toString` implementation from extending `Iterable`... On fix is to explicitly override `toString` in `MetaData` (or its sub classes), the other, much cleaner, is to remove this `MetaData extends Iterable[MetaData]` madness.

@bbarker quick review? This is a clean fix for the `override def toString` I've pushed in #53...