### PR TITLE
initial call location counting for Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ val view =
   </div>
 ```
 
+By default, a `Var` can only be mutated in one location, as this is the standard practice when using a `Var` for a local mutation or for using a `Var` to complete a cycle (cycles should be avoided if possible!). If you really need multiple mutation sites, you can set this explicitly:
+
+```scala
+val value: Var[Int] = Var(0, allowMultiMutations = true)
+```
+
 When mounting this view, [the implementation](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-html/src/main/scala/mhtml/mount.scala) will attach callbacks to each `Rx` such that changing `a`, `b` or `c` results in precise DOM updates:
 
 - Changing `a` will update the `div` attribute (reusing the same `div` node)

--- a/monadic-html/src/main/scala/mhtml/settings.scala
+++ b/monadic-html/src/main/scala/mhtml/settings.scala
@@ -18,7 +18,7 @@ trait MountSettings {
 }
 
 object MountSettings {
-  /** Production settings with fastOptJS a developement settings with fullOptJS. */
+  /** Production settings with fastOptJS a development settings with fullOptJS. */
   val default: MountSettings =
     if (LinkingInfo.productionMode)
       new ProdSettings {}
@@ -40,7 +40,7 @@ trait ProdSettings extends MountSettings {
   def inspectAttributeKey(att: String): Unit  = ()
 }
 
-/** Developement mode. Warns about unknown elements/attributes/events/EntityRef. */
+/** Development mode. Warns about unknown elements/attributes/events/EntityRef. */
 trait DevSettings extends MountSettings {
   def warn(message: String): Unit = println(s"[mhtml] Warning: $message")
 

--- a/monadic-html/src/test/scala/mhtml/HtmlTests.scala
+++ b/monadic-html/src/test/scala/mhtml/HtmlTests.scala
@@ -36,7 +36,7 @@ class HtmlTests extends FunSuite {
   }
 
   test("Updating binded String in Node Seq") {
-    val text: Var[String] = Var("original text")
+    val text: Var[String] = Var("original text", allowMultiMutations = true)
     val span: Elem = <span><p>pre {text} <br/> post </p></span>
     val div = dom.document.createElement("div")
     mount(div, span)
@@ -48,7 +48,7 @@ class HtmlTests extends FunSuite {
   }
 
   test("Updating binded Seq") {
-    val list: Var[Seq[String]] = Var(Seq("original text 0", "original text 1"))
+    val list: Var[Seq[String]] = Var(Seq("original text 0", "original text 1"), allowMultiMutations = true)
     val span: Elem = <span> <p> { list.map(xs => for (x <- xs) yield <b>{x}</b>) } </p> </span>
     val div = dom.document.createElement("div")
     mount(div, span)
@@ -60,7 +60,7 @@ class HtmlTests extends FunSuite {
   }
 
   test("Updating attribute") {
-    val id: Var[String] = Var("oldId")
+    val id: Var[String] = Var("oldId", allowMultiMutations = true)
     val hr: Elem = <hr id={id}/>
     val div = dom.document.createElement("div")
     mount(div, hr)
@@ -222,7 +222,7 @@ class HtmlTests extends FunSuite {
     var ext = 0
     def handler1(e: dom.MouseEvent): Unit = ext = 1
     def handler2(e: dom.MouseEvent): Unit = ext = 2
-    val varHandler = Var[dom.MouseEvent => Unit](handler1)
+    val varHandler = Var[dom.MouseEvent => Unit](handler1 _, allowMultiMutations = true)
     val button  = <button class="c" onclick={varHandler} id="1">Click Me!</button>
     val div = dom.document.createElement("div")
     mount(div, button)
@@ -243,13 +243,16 @@ class HtmlTests extends FunSuite {
     import scala.xml.Node
     import org.scalajs.dom
 
-    val count: Var[Int] = Var(0)
+    val count: Var[Int] = Var(0, allowMultiMutations = true)
 
     val doge: Node =
       <img style="width: 100px;" src="http://doge2048.com/meta/doge-600.png"/>
 
     val rxDoges: Rx[Seq[Node]] =
-      count.map(i => Seq.fill(i)(doge))
+      count.map({i =>
+        println("adding a doge!")
+        Seq.fill(i)(doge)
+      })
 
     val component = // ← look, you can even use fancy names!
       <div>
@@ -377,7 +380,7 @@ class HtmlTests extends FunSuite {
 
   test("mhtml-{onmount,onunmount} with Function0") {
     val div = dom.document.createElement("div")
-    val rx: Var[Option[xml.Node]] = Var(None)
+    val rx: Var[Option[xml.Node]] = Var(None, allowMultiMutations = true)
     var mounted = 0
     var unmounted = 0
     val node =
@@ -401,7 +404,7 @@ class HtmlTests extends FunSuite {
 
   test("mhtml-{onmount,onunmount} with Function1") {
     val div = dom.document.createElement("div")
-    val rx: Var[Option[xml.Node]] = Var(None)
+    val rx: Var[Option[xml.Node]] = Var(None, allowMultiMutations = true)
     var mounted = 0
     var unmounted = 0
     val node =

--- a/monadic-rx/js/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/js/src/main/scala/mhtml/rx.scala
@@ -1,0 +1,6 @@
+package mhtml
+
+object Platform {
+  private[mhtml] def checkIsProduction: Boolean =
+    scala.scalajs.LinkingInfo.productionMode
+}

--- a/monadic-rx/js/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/js/src/main/scala/mhtml/rx.scala
@@ -1,6 +1,6 @@
 package mhtml
 
-object Platform {
-  private[mhtml] def checkIsProduction: Boolean =
+private[mhtml] object Platform {
+  def checkIsProduction: Boolean =
     scala.scalajs.LinkingInfo.productionMode
 }

--- a/monadic-rx/jvm/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/jvm/src/main/scala/mhtml/rx.scala
@@ -1,0 +1,7 @@
+package mhtml
+
+object Platform {
+
+  //TODO: implement a JVM configuration
+  private[mhtml] def checkIsProduction: Boolean = false
+}

--- a/monadic-rx/jvm/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/jvm/src/main/scala/mhtml/rx.scala
@@ -1,7 +1,7 @@
 package mhtml
 
-object Platform {
+private[mhtml] object Platform {
 
   //TODO: implement a JVM configuration
-  private[mhtml] def checkIsProduction: Boolean = false
+  def checkIsProduction: Boolean = false
 }

--- a/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
+++ b/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
@@ -319,6 +319,30 @@ class RxTests extends FunSuite {
     assert(rx1.isHot && rx2.isHot)
   }
 
+  test("var multiassign check") {
+    val rx1: Var[Int] = Var(0, allowMultiMutations = false)
+    rx1 := 8
+    try {
+      rx1 := 9
+      fail()
+    }
+    catch {
+      case _: IllegalStateException => // Expected, so continue
+    }
+
+    val rx2: Var[Int] = Var(0, allowMultiMutations = true)
+    rx2 := 8
+    try {
+      rx2 := 9
+    }
+    catch {
+      case _: IllegalStateException => fail()
+    }
+
+    assert(rx1.isHot)
+    assert(rx2.isHot)
+  }
+
   test("pile printing from README") {
     val rx1 = Var(1)
     val rx2 = Var(2)

--- a/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
+++ b/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
@@ -18,8 +18,8 @@ class RxTests extends FunSuite {
 
   test("Scala.Rx README leak") {
     var count: Int = 0
-    val a: Var[Int] = Var(1)
-    val b: Var[Int] = Var(2)
+    val a: Var[Int] = Var(1, allowMultiMutations = true)
+    val b: Var[Int] = Var(2, allowMultiMutations = true)
     def mkRx(i: Int): Rx[Int] = b.map { v => count += 1; i + v }
 
     val c: Rx[Int] = a.flatMap(mkRx)
@@ -46,7 +46,7 @@ class RxTests extends FunSuite {
   }
 
   test("Referential transparency with map") {
-    val a: Var[Int] = Var(0)
+    val a: Var[Int] = Var(0, allowMultiMutations = true)
     val b: Rx[Int] = a.map(identity)
     assert(b.impure.value == 0)
     assert(a.map(identity).impure.value == 0)
@@ -60,7 +60,7 @@ class RxTests extends FunSuite {
   }
 
   test("max using foldp") {
-    val value: Var[Int] = Var(0)
+    val value: Var[Int] = Var(0, allowMultiMutations = true)
     val max: Rx[Int] = value.foldp(0)(_ max _)
     var current = -1
     val cc = max.impure.foreach(current = _)
@@ -77,7 +77,7 @@ class RxTests extends FunSuite {
   }
 
   test("keepIf") {
-    val numbers: Var[Int] = Var(0)
+    val numbers: Var[Int] = Var(0, allowMultiMutations = true)
     val even: Rx[Int] = numbers.keepIf(_ % 2 == 0)(-1)
     var numbersList: List[Int] = Nil
     var evenList: List[Int] = Nil
@@ -106,7 +106,7 @@ class RxTests extends FunSuite {
   }
 
   test("dropIf") {
-    val numbers: Var[Int] = Var(0)
+    val numbers: Var[Int] = Var(0, allowMultiMutations = true)
     val even: Rx[Int] = numbers.dropIf(_ % 2 == 0)(-1)
     var numbersList: List[Int] = Nil
     var evenList: List[Int] = Nil
@@ -126,7 +126,7 @@ class RxTests extends FunSuite {
   }
 
   test("collect") {
-    val numbers: Var[Int] = Var(0)
+    val numbers: Var[Int] = Var(0, allowMultiMutations = true)
     val even: Rx[Int] = numbers.collect { case x if x % 2 == 0 => x * 10 } (-1)
     var numbersList: List[Int] = Nil
     var evenList: List[Int] = Nil
@@ -154,7 +154,7 @@ class RxTests extends FunSuite {
   }
 
   test("dropRepeats") {
-    val numbers: Var[Int] = Var(0)
+    val numbers: Var[Int] = Var(0, allowMultiMutations = true)
     val noDups: Rx[Int] = numbers.dropRepeats
     var numbersList: List[Int] = Nil
     var noDupsList: List[Int] = Nil
@@ -176,8 +176,8 @@ class RxTests extends FunSuite {
   }
 
   test("merge") {
-    val rx1: Var[Int] = Var(0)
-    val rx2: Var[Int] = Var(1)
+    val rx1: Var[Int] = Var(0, allowMultiMutations = true)
+    val rx2: Var[Int] = Var(1, allowMultiMutations = true)
     val merged: Rx[Int] = rx1.merge(rx2)
     var rx1List: List[Int] = Nil
     var rx2List: List[Int] = Nil
@@ -201,7 +201,7 @@ class RxTests extends FunSuite {
 
   test("merge update") {
     val rx1: Var[Int] = Var(0)
-    val rx2: Var[Int] = Var(1)
+    val rx2: Var[Int] = Var(1, allowMultiMutations = true)
     val merged: Rx[Int] = rx1.merge(rx2)
     var value = -1
     val cc = merged.impure.foreach(value = _)
@@ -295,9 +295,9 @@ class RxTests extends FunSuite {
     }
   }
 
-  test("zip") {
-    val rx1: Var[Int] = Var(0)
-    val rx2: Var[Int] = Var(1)
+  test("product") {
+    val rx1: Var[Int] = Var(0, allowMultiMutations = true)
+    val rx2: Var[Int] = Var(1, allowMultiMutations = true)
     val zip: Rx[(Int, Int)] = rx1.zip(rx2)
     var rx1List: List[Int] = Nil
     var rx2List: List[Int] = Nil


### PR DESCRIPTION
This seems to work ... except in one case. For some reason, the doge example looks as though it doesn't need allowMultiMutations but I had to set `val count: Var[Int] = Var(0, allowMultiMutations = true)` for it to work. 

Currently the option is not configurable on the JVM; non-production is assumed in that case.