### PR TITLE
Rename product to zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This section presents the `Rx` API in its entirety. Let's start with the referen
 
     Together with `Rx#map` and `Rx.apply`, flatMap forms a `Monad`. [Proof](https://github.com/OlivierBlanvillain/monadic-html/blob/master/monadic-rx-cats/src/main/scala/mhtml/cats.scala).
 
--  `def product[B](other: Rx[B]): Rx[(A, B)]`
+-  `def zip[B](other: Rx[B]): Rx[(A, B)]`
 
     Create the Cartesian product of two `Rx`. The output tuple contains the
     latest values from each input `Rx`, which updates whenever the value from
@@ -172,9 +172,9 @@ This section presents the `Rx` API in its entirety. Let's start with the referen
     `for { a <- ra; b <- rb } yield (a, b)`.
 
     ```
-    // r1      => 0     8                       9     ...
-    // r2      => 1           4     5     6           ...
-    // product => (0,1) (8,1) (8,4) (8,5) (8,6) (9,6) ...
+    // r1  => 0     8                       9     ...
+    // r2  => 1           4     5     6           ...
+    // zip => (0,1) (8,1) (8,4) (8,5) (8,6) (9,6) ...
     ```
 
     This method, together with `Rx.apply`, forms am `Applicative`.

--- a/monadic-rx-cats/src/main/scala/mhtml/cats.scala
+++ b/monadic-rx-cats/src/main/scala/mhtml/cats.scala
@@ -219,7 +219,7 @@ object cats {
         }
 
       override def product[A, B](a: Rx[A], b: Rx[B]): Rx[(A, B)] =
-        a.product(b)
+        a.zip(b)
     }
 
   /**

--- a/monadic-rx/shared/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/shared/src/main/scala/mhtml/rx.scala
@@ -33,15 +33,18 @@ sealed trait Rx[+A] { self =>
    * `for { a <- ra; b <- rb } yield (a, b)`.
    *
    * ```
-   * // r1      => 0     8                       9     ...
-   * // r2      => 1           4     5     6           ...
-   * // product => (0,1) (8,1) (8,4) (8,5) (8,6) (9,6) ...
+   * // r1  => 0     8                       9     ...
+   * // r2  => 1           4     5     6           ...
+   * // zip => (0,1) (8,1) (8,4) (8,5) (8,6) (9,6) ...
    * ```
    *
    * This method, together with `Rx.apply`, forms am `Applicative`.
    * `|@|` syntax is available via the `monadic-rx-cats` package.
    */
-  def product[B](other: Rx[B]): Rx[(A, B)] = Product[A, B](this, other)
+  def zip[B](other: Rx[B]): Rx[(A, B)] = Zip[A, B](this, other)
+
+  @deprecated("Renamed to zip", "0.3.3")
+  def product[B](other: Rx[B]): Rx[(A, B)] = zip(other)
 
   /**
    * Drop repeated value of this `Rx`.
@@ -159,7 +162,7 @@ object Rx {
 
   final case class Map     [A, B]     (self: Rx[A], f: A => B)                      extends Rx[B]
   final case class FlatMap [A, B]     (self: Rx[A], f: A => Rx[B])                  extends Rx[B]
-  final case class Product [A, B]     (self: Rx[A], other: Rx[B])                   extends Rx[(A, B)]
+  final case class Zip [A, B]     (self: Rx[A], other: Rx[B])                   extends Rx[(A, B)]
   final case class DropRep [A]        (self: Rx[A])                                 extends Rx[A]
   final case class Merge   [A, B >: A](self: Rx[A], other: Rx[B])                   extends Rx[B]
   final case class Foldp   [A, B]     (self: Rx[A], seed: B, step: (B, A) => B)     extends Rx[B]
@@ -179,7 +182,7 @@ object Rx {
       }
       Cancelable { () => c1.cancel; c2.cancel }
 
-    case Product(self, other) =>
+    case Zip(self, other) =>
       var go = false
       var v1: Any = null
       var v2: Any = null

--- a/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
+++ b/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
@@ -225,10 +225,10 @@ class RxTests extends FunSuite {
       val rx2: Var[Int] = Var(2)
       val rx3: Rx[Int] =
         { // That's a nice oneliner with cats' |@|
-          (rx1: Rx[Int]) product
-          rx1 product
-          rx1 product
-          rx1 product
+          (rx1: Rx[Int]) zip
+          rx1 zip
+          rx1 zip
+          rx1 zip
           rx2.map { e => count = count + 1; e }
         }.map {
           case ((((i, _), _), _), j) => i + j
@@ -295,16 +295,16 @@ class RxTests extends FunSuite {
     }
   }
 
-  test("product") {
+  test("zip") {
     val rx1: Var[Int] = Var(0)
     val rx2: Var[Int] = Var(1)
-    val product: Rx[(Int, Int)] = rx1.product(rx2)
+    val zip: Rx[(Int, Int)] = rx1.zip(rx2)
     var rx1List: List[Int] = Nil
     var rx2List: List[Int] = Nil
-    var productList: List[(Int, Int)] = Nil
+    var zipList: List[(Int, Int)] = Nil
     val cc1 = rx1.impure.foreach(n => rx1List = rx1List :+ n)
     val cc2 = rx2.impure.foreach(n => rx2List = rx2List :+ n)
-    val ccm = product.impure.foreach(n => productList = productList :+ n)
+    val ccm = zip.impure.foreach(n => zipList = zipList :+ n)
     rx1 := 8
     rx2 := 4
     rx2 := 5
@@ -312,7 +312,7 @@ class RxTests extends FunSuite {
     rx1 := 9
     assert(rx1List == List(0, 8, 9))
     assert(rx2List == List(1, 4, 5, 6))
-    assert(productList == List((0, 1), (8, 1), (8, 4), (8, 5), (8, 6), (9, 6)))
+    assert(zipList == List((0, 1), (8, 1), (8, 4), (8, 5), (8, 6), (9, 6)))
     cc1.cancel
     cc2.cancel
     ccm.cancel


### PR DESCRIPTION
The `product` name makes more sense from a cats point of view, but cats users are probably going to use the raisin bread (|@|) operator regardless. `zip` is the other commonly used name (standard library, scalaz) that might be the first coming to the mind of most scala users.