### PR TITLE
Bump coursier version to prevent possible dep resolution issue

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.get-coursier"   % "sbt-coursier" % "1.0.0-RC8")
+addSbtPlugin("io.get-coursier"   % "sbt-coursier" % "1.0.0-RC12")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.0.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "1.1")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"  % "0.6.18")


### PR DESCRIPTION
I don't know why, but I was having some issues getting the project going on a new system. Bumping coursier helped. Here was the original error:

```
[info] Set current project to root (in build file:/home/brandon/workspace/monadic-html/)
[trace] Stack trace suppressed: run last monadic-rxJVM/*:ssExtractDependencies for the full output.
[trace] Stack trace suppressed: run last monadic-rxJVM/*:update for the full output.
[error] (monadic-rxJVM/*:ssExtractDependencies) coursier.ResolutionException: 1 not found
[error]     /home/brandon/.sbt/preloaded/org.scala-lang.modules/scala-parser-combinators_2.12/1.0.4/bundles/scala-parser-combinators_2.12.jar
[error] (monadic-rxJVM/*:update) coursier.ResolutionException: 1 not found
[error]     /home/brandon/.sbt/preloaded/org.scala-lang.modules/scala-parser-combinators_2.12/1.0.4/bundles/scala-parser-combinators_2.12.jar
[error] Total time: 3 s, completed Sep 25, 2017 1:57:58 PM
[IJ]> ;reload; set _root_.org.jetbrains.sbt.StructureKeys.sbtStructureOptions in Global := "download resolveClassifiers resolveSbtClassifiers" ;*/*:dumpStructureTo /tmp/sbt-structure.xml```