### PR TITLE
[WIP] add Rx.sharing 

### DIFF
--- a/monadic-rx/shared/src/main/scala/mhtml/rx.scala
+++ b/monadic-rx/shared/src/main/scala/mhtml/rx.scala
@@ -142,13 +142,6 @@ sealed trait Rx[+A] { self =>
    */
   def sampleOn[B](other: Rx[B]): Rx[A] = SampleOn[A, B](this, other)
 
-  /**
-    * Memoizes this `Rx` using an internal `Var`. This is primarily
-    * useful for optimizing an Rx graph, so that this `Rx` is only
-    * computed once.
-    */
-  def sharing: Rx[A] = Sharing[A](this)
-
   val impure: RxImpureOps[A] = RxImpureOps[A](this)
 }
 
@@ -161,6 +154,14 @@ case class RxImpureOps[+A](self: Rx[A]) extends AnyVal {
    * If you use this in your code, you are probably doing in wrong.
    */
   def foreach(effect: A => Unit): Cancelable = Rx.run(self)(effect)
+
+  /**
+    * Memoizes this `Rx` using an internal `Var`. This is primarily
+    * useful for optimizing an Rx graph, so that this `Rx` is only
+    * computed once.
+    */
+  @deprecated("This will eventually be made private and used under-the-hood, automatically.")
+  def sharing: Rx[A] = Rx.Sharing[A](self)
 }
 
 object Rx {

--- a/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
+++ b/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
@@ -80,7 +80,7 @@ class RxTests extends FunSuite {
     // Demonstrate sharing
     sourceVar := 0
     count = 0
-    val sharedSource: Rx[Int] = sourceVar.map{x => count +=1; x}.sharing
+    val sharedSource: Rx[Int] = sourceVar.map{x => count +=1; x}.impure.sharing
     assert(count == 0)
     val share1: Rx[Int] = sharedSource.map(identity)
     val share2: Rx[Int] = sharedSource.map(identity)

--- a/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
+++ b/monadic-rx/shared/src/test/scala/mhtml/RxTests.scala
@@ -73,7 +73,7 @@ class RxTests extends FunSuite {
     assert(noshare1.impure.value == 0)
     sourceVar := 1
     assert(noshare1.impure.value == 1)
-    assert(count == 6) //FIXME: should be 4?
+    assert(count == 6) // Note: impure.value calls increment also
     cc_ns1.cancel
     cc_ns2.cancel
 


### PR DESCRIPTION
I like both suggestions mentioned for sharing in #70 , but since the second largely depends on the first, I thought I'd try to get the ball rolling with the first. Unfortunately, updating upstream var doesn't propagate. When `run` operates on `Sharing`, the `foreach` (` self.impure.foreach{ x => ...`) doesn't seem to execute for updated values of the upstream Rx, i.e., `self`. I assume this is because I've made an egregious logic error, or perhaps more specifically, sharingCancelable is cancelled before it should be.

I'm also not sure if I needed to add those three sharing members to the Rx, but it seems like they needed to be persisted to the Rx.