### PR TITLE
test that demonstrates attribute (style) string modification

### DIFF
--- a/monadic-html/src/test/scala/mhtml/HtmlTests.scala
+++ b/monadic-html/src/test/scala/mhtml/HtmlTests.scala
@@ -274,6 +274,15 @@ class HtmlTests extends FunSuite {
     }
   }
 
+  test("style string unchanged") {
+    val displayStyle = "display:none;"
+    val innerDiv = <div style={ displayStyle }></div>
+    val div = dom.document.createElement("div")
+    mount(div, innerDiv)
+    val domInnerDiv = div.firstChild.asInstanceOf[dom.html.Div]
+    assert(domInnerDiv.outerHTML.contains(displayStyle))
+  }
+
   test("setUnsafeRawHTML") {
     val va: Var[String] = Var("")
     val ra = va.map(a => <div mhtml-onmount={ setUnsafeRawHTML(a) _ }></div>)


### PR DESCRIPTION
This is a failing test currently, and relates to a comment #92 where the style string is modified (spaces added); the end result doesn't affect html, but is a bit surprising and may affect code behavior that doesn't make the assumption that the string changes.