### PR TITLE
allowing event handlers that return Rxs

### DIFF
--- a/monadic-html/src/main/scala/scala/xml/xml.scala
+++ b/monadic-html/src/main/scala/scala/xml/xml.scala
@@ -1,7 +1,8 @@
 package scala.xml
 
-import language.higherKinds
+import mhtml.Rx
 
+import language.higherKinds
 import scala.annotation.implicitNotFound
 
 // XML Nodes ------------------------------------------------------------------
@@ -146,20 +147,23 @@ The following types are supported:
 - String
 - Boolean (false → remove attribute, true → empty attribute)
 - () => Unit, T => Unit event handler. Note: The return type needs to be Unit!
+- () => Rx[Unit], T => Rx[Unit] event handler, similar to the above.
 - mhtml.Var[T], mhtml.Rx[T] where T is XmlAttributeEmbeddable
 - Option[T] where T is XmlAttributeEmbeddable (None → remove from the DOM)
 """)
 trait XmlAttributeEmbeddable[T]
 object XmlAttributeEmbeddable {
   type XA[T] = XmlAttributeEmbeddable[T]
-  @inline implicit def noneAttributeEmbeddable:                             XA[None.type]    = null
-  @inline implicit def booleanAttributeEmbeddable:                          XA[Boolean]      = null
-  @inline implicit def stringAttributeEmbeddable:                           XA[String]       = null
-  @inline implicit def textNodeAttributeEmbeddable:                         XA[Text]         = null
-  @inline implicit def function0AttributeEmbeddable:                        XA[() => Unit]   = null
-  @inline implicit def function1AttributeEmbeddable[T]:                     XA[T => Unit]    = null
-  @inline implicit def optionAttributeEmbeddable[C[x] <: Option[x], T: XA]: XA[C[T]]         = null
-  @inline implicit def rxAttributeEmbeddable[C[x] <: mhtml.Rx[x], T: XA]:   XA[C[T]]         = null
+  @inline implicit def noneAttributeEmbeddable:                             XA[None.type]      = null
+  @inline implicit def booleanAttributeEmbeddable:                          XA[Boolean]        = null
+  @inline implicit def stringAttributeEmbeddable:                           XA[String]         = null
+  @inline implicit def textNodeAttributeEmbeddable:                         XA[Text]           = null
+  @inline implicit def function0AttributeEmbeddable:                        XA[() => Unit]     = null
+  @inline implicit def function1AttributeEmbeddable[T]:                     XA[T => Unit]      = null
+  @inline implicit def function0AttributeEmbeddableRx:                      XA[() => Rx[Unit]] = null
+  @inline implicit def function1AttributeEmbeddableRx[T]:                   XA[T => Rx[Unit]]  = null
+  @inline implicit def optionAttributeEmbeddable[C[x] <: Option[x], T: XA]: XA[C[T]]           = null
+  @inline implicit def rxAttributeEmbeddable[C[x] <: mhtml.Rx[x], T: XA]:   XA[C[T]]           = null
 }
 
 /** Evidence that T can be embedded in xml element position. */

--- a/monadic-html/src/test/scala/mhtml/HtmlTests.scala
+++ b/monadic-html/src/test/scala/mhtml/HtmlTests.scala
@@ -209,6 +209,19 @@ class HtmlTests extends FunSuite {
     assert(div.innerHTML == """<button class="c" id="1">Click Me!</button>""")
   }
 
+  test("onClick = Function1 rx") {
+    var clicked = false
+    def handler(e: dom.MouseEvent): Rx[Unit] = Rx({clicked = true})
+    val button  = <button class="c" onclick={handler _} id="1">Click Me!</button>
+    val div = dom.document.createElement("div")
+    mount(div, button)
+    assert(!clicked)
+    div.firstChild.asInstanceOf[dom.html.Button].click()
+    assert(clicked)
+    assert(div.innerHTML == """<button class="c" id="1">Click Me!</button>""")
+  }
+
+
   test("onClick = Var[Function0]") {
     var ext = 0
     def handler1(e: dom.MouseEvent): Unit = ext = 1


### PR DESCRIPTION
Use case:

```scala
            def actionHandler(ev: MouseEvent): Rx[Unit] = action.command().map {
              case Some(actRes) => actionResult := actRes
              case None => println("no RunResult")
            }
```

If this makes sense, would it be OK to publish an RC2 - I have some production code that may depend on this working, though I guess i could get around it by manually working with `Cancelable`s