### PR TITLE
monadic-scalatags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,19 +64,20 @@ lazy val `monadic-scalatags` = project
   .dependsOn(`monadic-rx`.js)
   .settings(
     testSettings,
-    libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.9.3",
-    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.1.0",
+    libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.12.0",
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % scalajsdom,
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % Test
   )
 
 lazy val `examples` = project
   .enablePlugins(ScalaJSPlugin)
-  .dependsOn(`monadic-html`, `monadic-rx-catsJS`)
+  .dependsOn(`monadic-html`, `monadic-rx-catsJS`, `monadic-scalatags`)
   .settings(
     testSettings,
     publish / skip := true,
     Test / test := {},
     libraryDependencies += "com.github.japgolly.scalacss" %%% "core" % "1.0.0",
+    libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.12.0",
     libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0")
 
 lazy val testSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,16 @@ lazy val `monadic-rx-cats`    = crossProject(JSPlatform, JVMPlatform)
     testSettings,
     libraryDependencies += "org.typelevel" %%% "cats-core" % cats)
 
+lazy val `monadic-scalatags` = project
+  .enablePlugins(ScalaJSPlugin)
+  .dependsOn(`monadic-rx`.js)
+  .settings(
+    testSettings,
+    libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.9.3",
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.1.0",
+    libraryDependencies += "org.scalatest" %%% "scalatest" % scalatest % Test
+  )
+
 lazy val `examples` = project
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(`monadic-html`, `monadic-rx-catsJS`)

--- a/examples/index.html
+++ b/examples/index.html
@@ -83,7 +83,7 @@
 
 </style>
 <script type="text/javascript"
-        src="target/scala-2.13/examples-opt.js"></script>
+        src="target/scala-2.13/examples-fastopt/main.js"></script>
 <script type="text/javascript">
     Main.main();
 </script>

--- a/examples/src/main/scala/mhtml/examples/Examples.scala
+++ b/examples/src/main/scala/mhtml/examples/Examples.scala
@@ -99,9 +99,7 @@ object Main {
 
   @JSExport
   def main(args: Array[String]): Unit = {
-    /*val div = dom.document.createElement("div")
-    div.appendChild(STContactList.app)
-    dom.document.body.appendChild(div)*/
+    dom.document.body.appendChild(STContactList.app)
     ()
   }
 }

--- a/examples/src/main/scala/mhtml/examples/Examples.scala
+++ b/examples/src/main/scala/mhtml/examples/Examples.scala
@@ -4,8 +4,8 @@ import scala.scalajs.js.annotation._
 import scala.util.Success
 import scala.xml.Node
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
-
 import mhtml._
+import mhtml.examples.STContactList
 import mhtml.future.syntax._
 import org.scalajs.dom
 import org.scalajs.dom.Event
@@ -99,7 +99,9 @@ object Main {
 
   @JSExport
   def main(args: Array[String]): Unit = {
-    mount(dom.document.body, mainApp)
+    /*val div = dom.document.createElement("div")
+    div.appendChild(STContactList.app)
+    dom.document.body.appendChild(div)*/
     ()
   }
 }

--- a/examples/src/main/scala/mhtml/examples/GithubAvatar.scala
+++ b/examples/src/main/scala/mhtml/examples/GithubAvatar.scala
@@ -26,7 +26,7 @@ trait GhRepo extends js.Object {
 }
 
 object GhRepo {
-  implicit val GhRepoSearchable: examples.Searcheable[examples.GhRepo] = Searcheable.instance[GhRepo](_.name)
+  implicit val GhRepoSearchable: Searcheable[GhRepo] = Searcheable.instance[GhRepo](_.name)
 }
 
 object GithubAvatar extends Example {

--- a/examples/src/main/scala/mhtml/examples/STContactList.scala
+++ b/examples/src/main/scala/mhtml/examples/STContactList.scala
@@ -13,11 +13,6 @@ object STContactList {
 
   implicit val cancelables = new BufferCancelable()
 
-  val container = dom.document.createElement("container")
-  val classVar: Var[String] = Var("foo")
-  val classRx: Rx[String] = classVar
-  container.appendChild(span(cls := classRx)().render)
-
   def row(contact: Contact) = {
     tr()(
       td(contact.name),

--- a/examples/src/main/scala/mhtml/examples/STContactList.scala
+++ b/examples/src/main/scala/mhtml/examples/STContactList.scala
@@ -36,7 +36,7 @@ object STContactList {
     section()(
       div()(
         button(
-          onclick := { contacts.update(x => Contact(Var("Olaf")) +: x)},
+          onclick := { () => contacts.update(x => Contact(Var("Olaf")) +: x)},
           "Add a contact"
         )
       ),

--- a/examples/src/main/scala/mhtml/examples/STContactList.scala
+++ b/examples/src/main/scala/mhtml/examples/STContactList.scala
@@ -1,0 +1,56 @@
+package mhtml.examples
+
+import mhtml.scalatags.mount.BufferCancelable
+import mhtml.{Rx, Var}
+import org.scalajs.dom
+import org.scalajs.dom.html.Element
+import scalatags.JsDom.all._
+import scalatags.JsDom.tags2._
+import mhtml.scalatags.mount._
+
+object STContactList {
+  case class Contact(name: Var[String])
+
+  implicit val cancelables = new BufferCancelable()
+
+  val container = dom.document.createElement("container")
+  val classVar: Var[String] = Var("foo")
+  val classRx: Rx[String] = classVar
+  container.appendChild(span(cls := classRx)().render)
+
+  def row(contact: Contact) = {
+    tr()(
+      td(contact.name),
+      td(
+        button(onclick := { () => contact.name.update("Mr." + _) })(
+          "click me"
+        )
+      )
+    )
+  }.render
+
+  def app: Element = {
+
+    val contacts = Var(Seq.empty[Contact])
+
+    section()(
+      div()(
+        button(
+          onclick := { contacts.update(x => Contact(Var("Olaf")) +: x)},
+          "Add a contact"
+        )
+      ),
+      table(
+        thead(
+          tr(
+            th("Name"),
+            th()
+          )
+        ),
+        tbody(
+          contacts.map(_.map(row))
+        )
+      )
+    ).render
+  }
+}

--- a/examples/src/main/scala/mhtml/examples/SelectList.scala
+++ b/examples/src/main/scala/mhtml/examples/SelectList.scala
@@ -26,7 +26,7 @@ case class Country(name: String, isoCode: String) {
   }
 }
 object Country {
-  implicit val countrySearchable: examples.Searcheable[examples.Country] = Searcheable.instance[Country](_.name)
+  implicit val countrySearchable: Searcheable[Country] = Searcheable.instance[Country](_.name)
 }
 
 object SelectList extends Example {

--- a/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
+++ b/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
@@ -36,8 +36,7 @@ object mount {
       val (start, end) = t.createMountSection()
       val c1 = rx.impure.run { a =>
         t.cleanMountSection(start, end)
-        println(s"rendering ${a.size} elements")
-        a.map(_.render).foreach(t.mountHere(_, Some(start)))
+        a.map(a => ev(a).render).foreach(t.mountHere(_, Some(start)))
       }
       cancelables.register(c1)
     }
@@ -46,7 +45,7 @@ object mount {
       val frag = org.scalajs.dom.document.createDocumentFragment()
       val c = rx.impure.run {
         a =>
-          a.map(_.render).foreach(frag.appendChild)
+          a.map(a => ev(a).render).foreach(frag.appendChild)
       }
       cancelables.register(c)
       frag
@@ -69,7 +68,7 @@ object mount {
       val (start, end) = t.createMountSection()
       val c1 = rx.impure.run { a =>
         t.cleanMountSection(start, end)
-        t.mountHere(a.render, Some(start))
+        t.mountHere(ev(a).render, Some(start))
       }
       cancelables.register(c1)
     }
@@ -78,7 +77,7 @@ object mount {
       val frag = org.scalajs.dom.document.createDocumentFragment()
       val c = rx.impure.run {
         a =>
-          frag.appendChild(a.render)
+          frag.appendChild(ev(a).render)
       }
       cancelables.register(c)
       frag

--- a/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
+++ b/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
@@ -1,0 +1,102 @@
+package mhtml.scalatags
+
+import mhtml.{Cancelable, Rx}
+import org.scalajs.dom
+import org.scalajs.dom.raw.Node
+import scalatags.JsDom.all.{Frag, s}
+import scalatags.Text.all._
+import scalatags.generic
+
+import java.util.Objects
+import scala.collection.mutable
+import scala.scalajs.js
+
+object mount {
+
+  trait Cancelables {
+    def register(c: Cancelable): Cancelable
+    def cancelAll(): Unit
+  }
+
+  class BufferCancelable extends Cancelables {
+    val buffer: mutable.Set[Cancelable] = mutable.Set.empty[Cancelable]
+
+    override def cancelAll: Unit = buffer.foreach(_.cancel())
+    def register(c: Cancelable): Cancelable = {
+      buffer += c
+      Cancelable(() => buffer -= c)
+    }
+  }
+
+  implicit def bindRx(implicit cancelables: Cancelables) =
+    new generic.AttrValue[dom.Element, Rx[String]]{
+      def apply(t: dom.Element, a: generic.Attr, rx: Rx[String]): Unit = {
+        val c = rx.impure.run { value =>
+          t.setAttribute(a.name, value)
+        }
+        cancelables.register(c)
+      }
+    }
+
+  implicit class RxFrag[A](rx: Rx[A])(implicit ev: A => Frag, cancelables: Cancelables) extends Frag {
+    Objects.requireNonNull(rx)
+    def applyTo(t: dom.Element): Unit = {
+      val (start, end) = t.createMountSection()
+      val c1 = rx.impure.run { a =>
+        t.cleanMountSection(start, end)
+        t.mountHere(a.render, Some(start))
+      }
+      cancelables.register(c1)
+    }
+
+    def render: dom.Node = {
+      val frag = org.scalajs.dom.document.createDocumentFragment()
+      val c = rx.impure.run {
+        a =>
+          frag.appendChild(a.render)
+      }
+      cancelables.register(c)
+      frag
+    }
+  }
+
+
+  implicit class NodeExtra(node: Node) {
+    def setEventListener[A](key: String, listener: A => Unit): Cancelable = {
+      val dyn = node.asInstanceOf[js.Dynamic]
+      dyn.updateDynamic(key)(listener)
+      Cancelable(() => dyn.updateDynamic(key)(null))
+    }
+
+    // Creates and inserts two empty text nodes into the DOM, which delimitate
+    // a mounting region between them point. Because the DOM API only exposes
+    // `.insertBefore` things are reversed: at the position of the `}`
+    // character in our binding example, we insert the start point, and at `{`
+    // goes the end.
+    def createMountSection(): (Node, Node) = {
+      val start = dom.document.createTextNode("")
+      val end   = dom.document.createTextNode("")
+      node.appendChild(end)
+      node.appendChild(start)
+      (start, end)
+    }
+
+    // Elements are then "inserted before" the start point, such that
+    // inserting List(a, b) looks as follows: `}` → `a}` → `ab}`. Note that a
+    // reference to the start point is sufficient here. */
+    def mountHere(child: Node, start: Option[Node]): Unit =
+      { start.fold(node.appendChild(child))(point => node.insertBefore(child, point)); () }
+
+    // Cleaning stuff is equally simple, `cleanMountSection` takes a references
+    // to start and end point, and (tail recursively) deletes nodes at the
+    // left of the start point until it reaches end of the mounting section. */
+    def cleanMountSection(start: Node, end: Node): Unit = {
+      val next = start.previousSibling
+      if (next != end) {
+        node.removeChild(next)
+        cleanMountSection(start, end)
+      }
+    }
+  }
+
+}

--- a/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
+++ b/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
@@ -2,6 +2,7 @@ package mhtml.scalatags
 
 import mhtml.{Cancelable, Rx}
 import org.scalajs.dom
+import org.scalajs.dom.Element
 import org.scalajs.dom.raw.Node
 import scalatags.JsDom.all.{Frag, s}
 import scalatags.Text.all._
@@ -28,7 +29,7 @@ object mount {
     }
   }
 
-  implicit def bindRx(implicit cancelables: Cancelables) =
+  implicit def bindRx(implicit cancelables: Cancelables): generic.AttrValue[Element, Rx[String]] =
     new generic.AttrValue[dom.Element, Rx[String]]{
       def apply(t: dom.Element, a: generic.Attr, rx: Rx[String]): Unit = {
         val c = rx.impure.run { value =>

--- a/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
+++ b/monadic-scalatags/src/main/scala/mhtml/scalatags/mount.scala
@@ -86,12 +86,6 @@ object mount {
 
 
   implicit class NodeExtra(node: dom.Node) {
-    def setEventListener[A](key: String, listener: A => Unit): Cancelable = {
-      val dyn = node.asInstanceOf[js.Dynamic]
-      dyn.updateDynamic(key)(listener)
-      Cancelable(() => dyn.updateDynamic(key)(null))
-    }
-
     // Creates and inserts two empty text nodes into the DOM, which delimitate
     // a mounting region between them point. Because the DOM API only exposes
     // `.insertBefore` things are reversed: at the position of the `}`

--- a/monadic-scalatags/src/test/scala/mhtml/ScalaTagTest.scala
+++ b/monadic-scalatags/src/test/scala/mhtml/ScalaTagTest.scala
@@ -1,0 +1,84 @@
+package mhtml
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalajs.dom
+import _root_.scalatags.JsDom.all._
+import org.scalatest.matchers.should.Matchers
+import mhtml.scalatags.mount._
+import org.scalajs.dom.html.Div
+import org.scalatest.BeforeAndAfter
+import _root_.scalatags.JsDom
+
+class ScalaTagTest extends AnyFunSuite with Matchers with BeforeAndAfter {
+
+  test("embed simple rx in string attribute") {
+    implicit val cancelables = new BufferCancelable()
+
+    val classVar: Var[String] = Var("foo")
+    val classRx: Rx[String] = classVar
+
+    val div = dom.document.createElement("container")
+    div.appendChild(span(cls := classRx)().render)
+    div.innerHTML shouldBe """<span class="foo"></span>"""
+    classVar := "qux"
+    div.innerHTML shouldBe """<span class="qux"></span>"""
+  }
+
+  test("embedded rx does effect the dom document") {
+    implicit val cancelables = new BufferCancelable()
+    val container = dom.document.createElement("container")
+    val classVar: Var[String] = Var("foo")
+    val classRx: Rx[String] = classVar
+    container.appendChild(span(cls := classRx)().render)
+    dom.document.body.appendChild(container)
+    dom.document.body.getElementsByTagName("container")(0).innerHTML shouldBe """<span class="foo"></span>"""
+    classVar := "bar"
+    dom.document.body.getElementsByTagName("container")(0).innerHTML shouldBe """<span class="bar"></span>"""
+  }
+
+  test("embed a rx node as child node") {
+
+    implicit val cancelables = new BufferCancelable()
+
+    val nodeVar = Var(div()("foo").render)
+    val nodeRx: Rx[Div] = nodeVar
+    val container = dom.document.createElement("container")
+    container.appendChild(span()(nodeRx).render)
+    container.innerHTML shouldBe "<span><div>foo</div></span>"
+    nodeVar := div()("bar").render
+    nodeVar := div()("qux").render
+    container.innerHTML shouldBe "<span><div>qux</div></span>"
+  }
+
+  test("embed a rx frag as child node") {
+
+    implicit val cancelables = new BufferCancelable()
+
+    val nodeVar = Var(div()("foo"))
+    val nodeRx: Rx[JsDom.TypedTag[Div]] = nodeVar
+    val container = dom.document.createElement("container")
+    container.appendChild(span()(nodeRx).render)
+    container.innerHTML shouldBe "<span><div>foo</div></span>"
+    nodeVar := div()("bar")
+    nodeVar := div()("qux")
+    container.innerHTML shouldBe "<span><div>qux</div></span>"
+  }
+
+  test("check how we aggregate cancellables") {
+
+    implicit val cancelables = new BufferCancelable()
+
+    val nodeVar = Var(div()("foo"))
+    val classVar = Var("blue")
+    val classRx: Rx[String] = classVar
+    val nodeRx: Rx[JsDom.TypedTag[Div]] = nodeVar
+    val container = dom.document.createElement("container")
+    container.appendChild(span(cls := classRx)(nodeRx).render)
+    container.innerHTML shouldBe """<span class="blue"><div>foo</div></span>"""
+    nodeVar := div()("bar")
+    nodeVar := div()("qux")
+    classVar := "red"
+    container.innerHTML shouldBe """<span class="red"><div>qux</div></span>"""
+    cancelables.buffer.size shouldBe 2
+  }
+}


### PR DESCRIPTION
Consider this to be in-progress, a draft.

The absence of types in the xml tags (in combination with my own stupidity) has lead to some bugs in my monadic-html based project in the past. Because of that I've been looking for a way to make my templates a bit more type-safe and during my experimentation I stumbled over scalatags and found that they make a surprisingly good match for monadic-html.

So I've been experimenting with this a while ago and I was wondering if we could bring this into monadic-html somehow.

As mentioned; this is a draft, a sketch, so I'm thankful for any feedback.




